### PR TITLE
Add configurable message format and reload command

### DIFF
--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="false" />
+  </component>
+</project>

--- a/src/main/java/net/pandadev/chattr/ConfigManager.java
+++ b/src/main/java/net/pandadev/chattr/ConfigManager.java
@@ -1,0 +1,83 @@
+package net.pandadev.chattr;
+
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.yaml.NodeStyle;
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ConfigManager {
+
+    private final Path configPath;
+    private ConfigurationNode root;
+
+    private String msgToTemplate;
+    private String msgFromTemplate;
+    private String replyToTemplate;
+    private String replyFromTemplate;
+
+    public ConfigManager(Path dataFolder) {
+        this.configPath = dataFolder.resolve("config.yml");
+    }
+
+    public void load() throws IOException {
+        if (Files.notExists(configPath)) {
+            Files.createDirectories(configPath.getParent());
+            try (var in = getClass().getResourceAsStream("/config.yml")) {
+                Files.copy(in, configPath);
+            }
+        }
+
+        var loader = YamlConfigurationLoader.builder()
+                .path(configPath)
+                .nodeStyle(NodeStyle.BLOCK)
+                .build();
+
+        root = loader.load();
+
+        boolean changed = false;
+
+        changed |= setDefault("messages", "privateMessageTo",
+                "<#ff6f00>[MSG To] <dark_gray>•</dark_gray> <white>{receiver}</white> <#ff6f00>{message}");
+        changed |= setDefault("messages", "privateMessageFrom",
+                "<#ff6f00>[MSG From] <dark_gray>•</dark_gray> <white>{sender}</white> <#ff6f00>{message}");
+        changed |= setDefault("messages", "replyMessageTo",
+                "<#ff6f00>[Reply To] <dark_gray>•</dark_gray> <white>{receiver}</white> <#ff6f00>{message}");
+        changed |= setDefault("messages", "replyMessageFrom",
+                "<#ff6f00>[Reply From] <dark_gray>•</dark_gray> <white>{sender}</white> <#ff6f00>{message}");
+
+        msgToTemplate = root.node("messages", "privateMessageTo").getString();
+        msgFromTemplate = root.node("messages", "privateMessageFrom").getString();
+        replyToTemplate = root.node("messages", "replyMessageTo").getString();
+        replyFromTemplate = root.node("messages", "replyMessageFrom").getString();
+
+        if (changed) {
+            loader.save(root);
+        }
+    }
+
+    private boolean setDefault(String category, String key, String defaultValue) {
+        var node = root.node(category, key);
+        if (node.virtual() || node.getString() == null) {
+            try {
+                node.set(defaultValue);
+            } catch (SerializationException e) {
+                e.printStackTrace();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public void reload() throws IOException {
+        load();
+    }
+
+    public String getMsgToTemplate() {return msgToTemplate;}
+    public String getMsgFromTemplate() {return msgFromTemplate;}
+    public String getReplyToTemplate() {return replyToTemplate;}
+    public String getReplyFromTemplate() {return replyFromTemplate;}
+}

--- a/src/main/java/net/pandadev/chattr/Main.java
+++ b/src/main/java/net/pandadev/chattr/Main.java
@@ -1,18 +1,23 @@
 package net.pandadev.chattr;
 
 import com.google.inject.Inject;
-import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
 import org.slf4j.Logger;
 
-@Plugin(id = "chattr",
+import java.io.IOException;
+import java.nio.file.Path;
+
+@Plugin(
+        id = "chattr",
         name = "Chattr",
         version = "1.0",
         description = "A simple msg plugin for Velocity proxies",
         url = "https://pandadev.net",
-        authors = {"PandaDEV"})
+        authors = {"PandaDEV"}
+)
 public class Main {
 
     @Inject
@@ -22,19 +27,40 @@ public class Main {
     private ProxyServer server;
 
     private final Metrics.Factory metricsFactory;
+    private ConfigManager config;
+
 
     @Inject
     public Main(Metrics.Factory metricsFactory) {
         this.metricsFactory = metricsFactory;
     }
 
+    @Inject
+    public void initConfig(@com.velocitypowered.api.plugin.annotation.DataDirectory Path dataDirectory) {
+        this.config = new ConfigManager(dataDirectory);
+    }
+
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
         logger.info("Chattr plugin is initializing.");
-        server.getCommandManager().register("msg", new Commands.MsgCommand(server), "chat", "tell", "w");
-        server.getCommandManager().register("r", new Commands.ReplyCommand(), "reply");
+
+        try {
+            config.load();
+        } catch (IOException e) {
+            logger.error("Failed to load config.yml", e);
+            return;
+        }
+
+        server.getCommandManager().register( "msg", new Commands.MsgCommand(server, config),"chat", "tell", "w");
+        server.getCommandManager().register("r", new Commands.ReplyCommand(config),"reply");
+        server.getCommandManager().register("chattrreload", new Commands.ReloadCommand(this, config));
 
         int pluginId = 21956;
         metricsFactory.make(this, pluginId);
+    }
+
+    public void reloadConfig() throws Exception {
+        this.config.reload();
+        logger.info("Config reloaded.");
     }
 }

--- a/src/main/java/net/pandadev/chattr/Main.java
+++ b/src/main/java/net/pandadev/chattr/Main.java
@@ -31,7 +31,7 @@ public class Main {
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
         logger.info("Chattr plugin is initializing.");
-        server.getCommandManager().register("msg", new Commands.MsgCommand(server), "chat");
+        server.getCommandManager().register("msg", new Commands.MsgCommand(server), "chat", "tell", "w");
         server.getCommandManager().register("r", new Commands.ReplyCommand(), "reply");
 
         int pluginId = 21956;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,5 @@
+messages:
+  privateMessageTo: "<#ff6f00>[MSG To] <dark_gray>•</dark_gray> <white>{receiver}</white> <#ff6f00>{message}"
+  privateMessageFrom: "<#ff6f00>[MSG From] <dark_gray>•</dark_gray> <white>{sender}</white> <#ff6f00>{message}"
+  replyMessageTo: "<#ff6f00>[Reply To] <dark_gray>•</dark_gray> <white>{receiver}</white> <#ff6f00>{message}"
+  replyMessageFrom: "<#ff6f00>[Reply From] <dark_gray>•</dark_gray> <white>{sender}</white> <#ff6f00>{message}"


### PR DESCRIPTION
### Summary
This PR introduces two new features:
- A config option to customize the message format.
- A command (`/chattrreload`) to reload the config without restarting.
- Support for `/tell` and `/w` commands as aliases for private messaging.

### Why
- These changes make the mod more flexible for server owners and easier to use when adjusting settings.
- `/tell` and `/w` provide familiar alternatives that players expect by default.

### Notes
- Defaults remain unchanged if the config is not modified.
- Reload command is permission-restricted.
