### PR TITLE
fix: add permission check for selectors in /msg

### DIFF
--- a/src/main/java/net/pandadev/chattr/Commands.java
+++ b/src/main/java/net/pandadev/chattr/Commands.java
@@ -72,15 +72,19 @@ public class Commands {
             List<String> suggestions = new ArrayList<>();
 
             if (args.length == 0 || args.length == 1) {
-                suggestions.add("@a");
-                suggestions.add("@r");
-                suggestions.add("@s");
-
                 CommandSource finalSource = invocation.source();
+
+                if (finalSource.hasPermission("chattr.msgselector")) {
+                    suggestions.add("@a");
+                    suggestions.add("@r");
+                    suggestions.add("@s");
+                }
+
                 suggestions.addAll(server.getAllPlayers().stream()
                         .map(Player::getUsername)
                         .toList());
             }
+
             if (args.length == 1 && !args[0].isEmpty()) {
                 String currentInput = args[0].toLowerCase();
                 return suggestions.stream()
@@ -91,6 +95,10 @@ public class Commands {
         }
 
         private List<Player> resolveSelector(String selector, CommandSource source) {
+            if (selector.startsWith("@") && !source.hasPermission("chattr.msgselector")) {
+                return List.of();
+            }
+
             return switch (selector) {
                 case "@a" -> new ArrayList<>(server.getAllPlayers());
                 case "@r" -> {

--- a/src/main/java/net/pandadev/chattr/Main.java
+++ b/src/main/java/net/pandadev/chattr/Main.java
@@ -51,7 +51,7 @@ public class Main {
             return;
         }
 
-        server.getCommandManager().register( "msg", new Commands.MsgCommand(server, config),"chat", "tell", "w");
+        server.getCommandManager().register("msg", new Commands.MsgCommand(server, config),"chat", "tell", "w");
         server.getCommandManager().register("r", new Commands.ReplyCommand(config),"reply");
         server.getCommandManager().register("chattrreload", new Commands.ReloadCommand(this, config));
 


### PR DESCRIPTION
This PR fixes an issue where players could use selectors (e.g. @a) in /msg 
without restriction, allowing them to send messages to all players at once 
(e.g. for advertising).

Changes:
- Added `chattr.msgselector` permission to control access to selectors
- Updated tab-completion to only suggest selectors if the sender has permission
- If a player without permission tries to use a selector, the command now
  behaves as if the selector is invalid ("Player not found")

Fixes #1
